### PR TITLE
fixed issue with writing volume names to file

### DIFF
--- a/src/plugins/raid.py
+++ b/src/plugins/raid.py
@@ -71,7 +71,9 @@ class RaidAutomator(ClusterSetup):
         all_dev = ' '.join(dev_names)
 
         #writing names to file for future volume cleanup
-        with open('vol_names.txt','w') as f:
+        home = os.path.expanduser("~")
+        fpath = home + "/.starcluster/plugins/vol_names.txt"
+            with open(fpath,'w') as f:
             for x in vol_names:
                 f.write('%s\n' %x)
 


### PR DESCRIPTION
fixed issue in raid.py that was writing the volume names to the wrong file (for VOLUME_CLEANUP)
